### PR TITLE
Fix: Import & Analyze sidebar link highlighting

### DIFF
--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -294,13 +294,13 @@ export const SideNav: React.FC = () => {
       <div style={{ marginBottom: '1.5rem' }}>
         <h3 style={{ padding: '0 1.5rem', fontSize: '0.75rem', textTransform: 'uppercase', color: 'rgba(252, 211, 77, 0.7)', fontWeight: '500', marginBottom: '0.5rem' }}>TOOLS</h3>
         <ul>
-          {/* Add Import & Analyze link */}
+          {/* Add Import & Analyze link - Fix: Ensure this path works correctly by checking with the routes.tsx config */}
           <li>
             <Link
               to="/import"
-              style={isActive('/import') ? activeStyle : navItemStyle}
+              style={isActive('/import') || isActive('/analyze-progress') || isActive('/analysis-results') ? activeStyle : navItemStyle}
               onMouseOver={(e) => {e.currentTarget.style.backgroundColor = '#2d2e33'}}
-              onMouseOut={(e) => {if (!isActive('/import')) e.currentTarget.style.backgroundColor = 'transparent'}}
+              onMouseOut={(e) => {if (!isActive('/import') && !isActive('/analyze-progress') && !isActive('/analysis-results')) e.currentTarget.style.backgroundColor = 'transparent'}}
             >
               <FaFileImport style={{ marginRight: '0.5rem' }} />
               <span>Import & Analyze</span>

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 export const version = {
   major: 0,
   minor: 9,
-  patch: 49,
+  patch: 50,
   date: '2025-05-15',
-  notes: 'EMERGENCY FIX: Completely rewrote StoryAnalysisProgress component to bypass SupabaseService and directly access the database. This implementation uses direct database queries with explicit deduplication checks for each entity type. Previous version (0.9.48): Enhanced StoryAnalysisProgress with error handling and debugging.'
+  notes: 'Fixed Import & Analyze sidebar link to properly highlight when navigating through the analysis workflow (initial import, progress, and results pages). Previous version (0.9.49): EMERGENCY FIX: Completely rewrote StoryAnalysisProgress component to bypass SupabaseService and directly access the database.'
 };


### PR DESCRIPTION
## Description
This PR fixes an issue with the "Import & Analyze" sidebar link where clicking it would navigate correctly but the link wasn't staying highlighted while moving through the analysis workflow.

## Changes
- Updated the SideNav component to properly highlight the "Import & Analyze" link when the user is on any part of the analysis flow (`/import`, `/analyze-progress`, or `/analysis-results`)
- Updated version.ts to 0.9.50 to reflect this change

## Test Plan
1. Click on "Import & Analyze" in the sidebar
2. Observe that the link is highlighted
3. Select a Story World, Story, and file for upload
4. Click "Analyze"
5. Verify that the sidebar link remains highlighted during the analysis progress
6. Verify that the sidebar link remains highlighted when viewing the results